### PR TITLE
Upgrade to Scout 0.3.0, and have --query-only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
 requests==2.18.4
-scout.py==0.1.5
+scout.py==0.3.0
 pathlib2==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         "click==6.7",
         "requests==2.18.4",
-        "scout.py==0.1.5",
+        "scout.py==0.3.0",
         "pathlib2==2.3.0"
     ],
     entry_points="""


### PR DESCRIPTION
`kubernaut kubeconfig --query-only` won't output anything on success, and will use the exit code to indicate if you have a cluster claimed.
